### PR TITLE
Changes from background agent bc-57a2dda2-042c-4a3b-8270-87330dd5307b

### DIFF
--- a/ENTITIES_SUMMARY.md
+++ b/ENTITIES_SUMMARY.md
@@ -1,0 +1,322 @@
+# SmartQuiz Platform - JPA Entities Summary
+
+This document provides an overview of all the JPA entities created for the SmartQuiz platform, organized by functional domains.
+
+## Project Structure
+
+```
+src/main/java/com/example/mrquiz/
+├── entity/
+│   ├── BaseEntity.java                    # Base entity with common fields
+│   ├── auth/                              # Authentication & User Management
+│   │   ├── User.java
+│   │   ├── UserProfile.java
+│   │   ├── AuthToken.java
+│   │   └── UserSession.java
+│   ├── core/                              # Core Business Entities
+│   │   ├── Institution.java
+│   │   ├── Department.java
+│   │   ├── UserInstitution.java
+│   │   ├── Course.java
+│   │   └── CourseEnrollment.java
+│   ├── quiz/                              # Quiz System
+│   │   ├── Quiz.java
+│   │   ├── Question.java
+│   │   ├── QuizQuestion.java
+│   │   ├── QuizSession.java
+│   │   ├── QuizAttempt.java
+│   │   ├── QuestionResponse.java
+│   │   └── ResponseFile.java
+│   ├── file/                              # File Management
+│   │   ├── File.java
+│   │   └── FileVariant.java
+│   ├── analytics/                         # Analytics & Reporting
+│   │   ├── QuestionAnalytics.java
+│   │   └── UserAnalytics.java
+│   └── security/                          # Security & Audit
+│       ├── AuditLog.java
+│       └── SecurityIncident.java
+└── enums/                                 # Enum Types
+    ├── UserRole.java
+    ├── UserStatus.java
+    ├── TokenType.java
+    ├── InstitutionType.java
+    ├── InstitutionStatus.java
+    ├── InstitutionRole.java
+    ├── MembershipStatus.java
+    ├── CourseStatus.java
+    ├── EnrollmentType.java
+    ├── EnrollmentStatus.java
+    ├── QuizType.java
+    ├── QuizStatus.java
+    ├── QuestionType.java
+    ├── QuestionStatus.java
+    ├── DifficultyLevel.java
+    ├── SessionStatus.java
+    ├── AttemptStatus.java
+    ├── FileType.java
+    ├── FileStatus.java
+    ├── SeverityLevel.java
+    └── IncidentType.java
+```
+
+## Entity Domains
+
+### 1. Authentication & User Management (`auth` package)
+
+#### User
+- **Purpose**: Core user entity with authentication and profile information
+- **Key Features**:
+  - Email/username authentication
+  - MFA support
+  - Role-based access control
+  - Security tracking (failed attempts, account locking)
+  - Flexible metadata storage (JSONB)
+
+#### UserProfile
+- **Purpose**: Extended user profile information
+- **Key Features**:
+  - Academic and professional information
+  - Social media links
+  - Notification and privacy preferences
+  - Performance statistics
+
+#### AuthToken
+- **Purpose**: Authentication tokens management
+- **Key Features**:
+  - Multiple token types (email verification, password reset, etc.)
+  - Expiration and usage tracking
+  - Secure token hashing
+
+#### UserSession
+- **Purpose**: User session tracking
+- **Key Features**:
+  - Session token management
+  - Device and location tracking
+  - Activity monitoring
+
+### 2. Core Business Entities (`core` package)
+
+#### Institution
+- **Purpose**: Educational institutions/organizations
+- **Key Features**:
+  - Multi-tenant support
+  - Branding and configuration
+  - Subscription and billing integration
+  - Feature flags and limits
+
+#### Department
+- **Purpose**: Organizational departments within institutions
+- **Key Features**:
+  - Hierarchical structure support
+  - Department head assignment
+  - Custom settings
+
+#### UserInstitution
+- **Purpose**: User-institution relationship mapping
+- **Key Features**:
+  - Role-based membership
+  - Student/employee ID tracking
+  - Permission management
+  - Membership lifecycle tracking
+
+#### Course
+- **Purpose**: Academic courses
+- **Key Features**:
+  - Semester and academic year tracking
+  - Instructor and TA assignment
+  - Prerequisites management
+  - Grading scale configuration
+
+#### CourseEnrollment
+- **Purpose**: Student course enrollments
+- **Key Features**:
+  - Multiple enrollment types (regular, audit, etc.)
+  - Grade tracking
+  - Enrollment lifecycle management
+
+### 3. Quiz System (`quiz` package)
+
+#### Quiz
+- **Purpose**: Main quiz/assessment entity
+- **Key Features**:
+  - Multiple quiz types (quiz, exam, survey, etc.)
+  - Advanced timing controls
+  - Security and proctoring settings
+  - Flexible question presentation options
+  - Access control and scheduling
+
+#### Question
+- **Purpose**: Question bank with rich question types
+- **Key Features**:
+  - 17 different question types (including clinical cases)
+  - Flexible JSON-based question data storage
+  - File attachment support
+  - Analytics and performance tracking
+  - Versioning and sharing capabilities
+
+#### QuizQuestion
+- **Purpose**: Quiz-question relationship with customization
+- **Key Features**:
+  - Question ordering and grouping
+  - Point override capabilities
+  - Section organization
+  - Per-question settings
+
+#### QuizSession
+- **Purpose**: Live quiz sessions for group activities
+- **Key Features**:
+  - Session code generation
+  - Real-time participation
+  - Leaderboard support
+  - Access control
+
+#### QuizAttempt
+- **Purpose**: Individual quiz attempts
+- **Key Features**:
+  - Multiple attempt support
+  - Comprehensive timing tracking
+  - Security and proctoring data
+  - Device and browser information
+  - Scoring and grading
+
+#### QuestionResponse
+- **Purpose**: Individual question responses
+- **Key Features**:
+  - Flexible JSON-based answer storage
+  - Automatic and manual grading support
+  - Response timing and behavior tracking
+  - Confidence level recording
+
+#### ResponseFile
+- **Purpose**: File attachments for question responses
+- **Key Features**:
+  - File upload support for responses
+  - Description and ordering
+  - Integration with file management system
+
+### 4. File Management (`file` package)
+
+#### File
+- **Purpose**: Comprehensive file storage system
+- **Key Features**:
+  - Multiple storage providers (local, S3, etc.)
+  - File processing and variants
+  - Access control and permissions
+  - Deduplication via hash
+  - Lifecycle management
+
+#### FileVariant
+- **Purpose**: Different file formats and sizes
+- **Key Features**:
+  - Thumbnail generation
+  - Format conversion
+  - Size optimization
+  - Processing metadata
+
+### 5. Analytics & Reporting (`analytics` package)
+
+#### QuestionAnalytics
+- **Purpose**: Question performance analytics
+- **Key Features**:
+  - Success rate calculation
+  - Difficulty and discrimination indices
+  - Time analysis
+  - Answer pattern analysis
+  - Common mistake tracking
+
+#### UserAnalytics
+- **Purpose**: User performance analytics
+- **Key Features**:
+  - Comprehensive performance metrics
+  - Learning pattern analysis
+  - Engagement tracking
+  - Improvement trends
+  - Subject area analysis
+
+### 6. Security & Audit (`security` package)
+
+#### AuditLog
+- **Purpose**: Comprehensive audit logging
+- **Key Features**:
+  - Change tracking (old/new values)
+  - Request context capture
+  - Action classification
+  - Severity levels
+  - User and session tracking
+
+#### SecurityIncident
+- **Purpose**: Security incident management
+- **Key Features**:
+  - Multiple incident types
+  - Evidence collection
+  - Investigation workflow
+  - Resolution tracking
+  - Confidence scoring
+
+## Key Technical Features
+
+### 1. PostgreSQL Integration
+- **JSONB Support**: Extensive use of JSONB columns for flexible data storage
+- **UUID Primary Keys**: All entities use UUID for better scalability
+- **Comprehensive Indexing**: Strategic indexes for query performance
+- **Enum Integration**: Java enums mapped to PostgreSQL custom types
+
+### 2. JPA/Hibernate Features
+- **Lazy Loading**: Optimized relationship loading
+- **Auditing**: Automatic timestamp management
+- **Custom Types**: JSONB type handling
+- **Inheritance**: BaseEntity for common fields
+
+### 3. Lombok Integration
+- **@Data**: Automatic getters, setters, toString, equals, hashCode
+- **@EqualsAndHashCode**: Proper equality handling with inheritance
+- **Clean Code**: Reduced boilerplate
+
+### 4. Flexible Architecture
+- **JSON Storage**: Extensible metadata and settings
+- **Multi-tenancy**: Institution-based data isolation
+- **Versioning**: Question versioning support
+- **File System**: Comprehensive file management
+
+## Database Schema Compliance
+
+All entities are designed to match the PostgreSQL database schema provided, including:
+- Exact table and column names
+- Proper foreign key relationships
+- Index definitions
+- Constraint specifications
+- Data types and precision
+
+## Usage Examples
+
+### Creating a Quiz
+```java
+Quiz quiz = new Quiz();
+quiz.setTitle("Midterm Exam");
+quiz.setQuizType(QuizType.EXAM);
+quiz.setCreator(user);
+quiz.setCourse(course);
+quiz.setTimeLimit(120); // 2 hours
+quiz.setStatus(QuizStatus.DRAFT);
+```
+
+### Adding Questions to Quiz
+```java
+QuizQuestion quizQuestion = new QuizQuestion();
+quizQuestion.setQuiz(quiz);
+quizQuestion.setQuestion(question);
+quizQuestion.setOrderIndex(1);
+quizQuestion.setPoints(BigDecimal.valueOf(10));
+```
+
+### Recording Quiz Attempt
+```java
+QuizAttempt attempt = new QuizAttempt();
+attempt.setQuiz(quiz);
+attempt.setUser(student);
+attempt.setStatus(AttemptStatus.IN_PROGRESS);
+attempt.setStartedAt(LocalDateTime.now());
+```
+
+This entity structure provides a solid foundation for the SmartQuiz platform, supporting all the features outlined in the database schema while maintaining clean, maintainable Java code.

--- a/src/main/java/com/example/mrquiz/entity/BaseEntity.java
+++ b/src/main/java/com/example/mrquiz/entity/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.example.mrquiz.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@MappedSuperclass
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public abstract class BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @EqualsAndHashCode.Include
+    private UUID id;
+    
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/mrquiz/entity/analytics/QuestionAnalytics.java
+++ b/src/main/java/com/example/mrquiz/entity/analytics/QuestionAnalytics.java
@@ -1,0 +1,92 @@
+package com.example.mrquiz.entity.analytics;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.core.Institution;
+import com.example.mrquiz.entity.quiz.Question;
+import com.example.mrquiz.entity.quiz.Quiz;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "question_analytics", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"question_id", "quiz_id", "period_start", "period_end"}),
+       indexes = @Index(name = "idx_question_analytics_question", columnList = "question_id, period_start"))
+public class QuestionAnalytics extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id")
+    private Quiz quiz;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id")
+    private Institution institution;
+    
+    // Time period for analytics
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+    
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+    
+    // Basic statistics
+    @Column(name = "total_attempts")
+    private Integer totalAttempts = 0;
+    
+    @Column(name = "correct_attempts")
+    private Integer correctAttempts = 0;
+    
+    @Column(name = "partially_correct_attempts")
+    private Integer partiallyCorrectAttempts = 0;
+    
+    @Column(name = "incorrect_attempts")
+    private Integer incorrectAttempts = 0;
+    
+    // Performance metrics
+    @Column(name = "success_rate", precision = 5, scale = 4)
+    private BigDecimal successRate;
+    
+    @Column(name = "average_score", precision = 5, scale = 2)
+    private BigDecimal averageScore;
+    
+    @Column(name = "difficulty_index", precision = 5, scale = 4)
+    private BigDecimal difficultyIndex;
+    
+    @Column(name = "discrimination_index", precision = 5, scale = 4)
+    private BigDecimal discriminationIndex;
+    
+    // Time analysis
+    @Column(name = "average_time_spent", precision = 10, scale = 2)
+    private BigDecimal averageTimeSpent;
+    
+    @Column(name = "median_time_spent", precision = 10, scale = 2)
+    private BigDecimal medianTimeSpent;
+    
+    @Column(name = "time_efficiency_score", precision = 5, scale = 4)
+    private BigDecimal timeEfficiencyScore;
+    
+    // Answer pattern analysis
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "answer_distribution", columnDefinition = "jsonb")
+    private Map<String, Object> answerDistribution;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "common_mistakes", columnDefinition = "jsonb")
+    private Map<String, Object> commonMistakes;
+    
+    @Column(name = "last_calculated")
+    private LocalDateTime lastCalculated = LocalDateTime.now();
+}

--- a/src/main/java/com/example/mrquiz/entity/analytics/UserAnalytics.java
+++ b/src/main/java/com/example/mrquiz/entity/analytics/UserAnalytics.java
@@ -1,0 +1,122 @@
+package com.example.mrquiz.entity.analytics;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.entity.core.Course;
+import com.example.mrquiz.entity.core.Institution;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "user_analytics", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "course_id", "subject_area", "period_start", "period_end"}),
+       indexes = @Index(name = "idx_user_analytics_user_course", columnList = "user_id, course_id, period_start"))
+public class UserAnalytics extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id")
+    private Institution institution;
+    
+    // Time period for analytics
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+    
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+    
+    @Column(name = "subject_area", length = 100)
+    private String subjectArea;
+    
+    // Quiz statistics
+    @Column(name = "total_quizzes_taken")
+    private Integer totalQuizzesTaken = 0;
+    
+    @Column(name = "total_quizzes_completed")
+    private Integer totalQuizzesCompleted = 0;
+    
+    @Column(name = "total_questions_answered")
+    private Integer totalQuestionsAnswered = 0;
+    
+    @Column(name = "correct_answers")
+    private Integer correctAnswers = 0;
+    
+    @Column(name = "partially_correct_answers")
+    private Integer partiallyCorrectAnswers = 0;
+    
+    // Performance metrics
+    @Column(name = "average_score", precision = 5, scale = 2)
+    private BigDecimal averageScore;
+    
+    @Column(name = "median_score", precision = 5, scale = 2)
+    private BigDecimal medianScore;
+    
+    @Column(name = "best_score", precision = 5, scale = 2)
+    private BigDecimal bestScore;
+    
+    @Column(name = "worst_score", precision = 5, scale = 2)
+    private BigDecimal worstScore;
+    
+    @Column(name = "improvement_trend", precision = 5, scale = 4)
+    private BigDecimal improvementTrend;
+    
+    @Column(name = "consistency_score", precision = 5, scale = 4)
+    private BigDecimal consistencyScore;
+    
+    // Time analysis
+    @Column(name = "total_time_spent")
+    private Integer totalTimeSpent = 0;
+    
+    @Column(name = "average_time_per_quiz")
+    private Integer averageTimePerQuiz;
+    
+    @Column(name = "time_efficiency_score", precision = 5, scale = 4)
+    private BigDecimal timeEfficiencyScore;
+    
+    // Learning patterns
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "preferred_question_types", columnDefinition = "jsonb")
+    private Map<String, Object> preferredQuestionTypes;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "strongest_topics", columnDefinition = "jsonb")
+    private List<String> strongestTopics;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "weakest_topics", columnDefinition = "jsonb")
+    private List<String> weakestTopics;
+    
+    @Column(name = "learning_velocity", precision = 5, scale = 4)
+    private BigDecimal learningVelocity;
+    
+    // Engagement metrics
+    @Column(name = "participation_rate", precision = 5, scale = 2)
+    private BigDecimal participationRate;
+    
+    @Column(name = "completion_rate", precision = 5, scale = 2)
+    private BigDecimal completionRate;
+    
+    @Column(name = "review_frequency")
+    private Integer reviewFrequency = 0;
+    
+    @Column(name = "last_updated")
+    private LocalDateTime lastUpdated = LocalDateTime.now();
+}

--- a/src/main/java/com/example/mrquiz/entity/auth/AuthToken.java
+++ b/src/main/java/com/example/mrquiz/entity/auth/AuthToken.java
@@ -1,0 +1,43 @@
+package com.example.mrquiz.entity.auth;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.enums.TokenType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "auth_tokens", indexes = {
+    @Index(name = "idx_token_hash", columnList = "tokenHash"),
+    @Index(name = "idx_token_user_type", columnList = "user_id, tokenType")
+})
+public class AuthToken extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @Column(name = "token_hash", nullable = false)
+    private String tokenHash;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "token_type", nullable = false)
+    private TokenType tokenType;
+    
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+    
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> metadata;
+}

--- a/src/main/java/com/example/mrquiz/entity/auth/User.java
+++ b/src/main/java/com/example/mrquiz/entity/auth/User.java
@@ -1,0 +1,100 @@
+package com.example.mrquiz.entity.auth;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.file.File;
+import com.example.mrquiz.enums.UserRole;
+import com.example.mrquiz.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+    
+    @Column(nullable = false, unique = true)
+    private String email;
+    
+    @Column(unique = true, length = 100)
+    private String username;
+    
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+    
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+    
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role = UserRole.STUDENT;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+    
+    // Authentication fields
+    @Column(name = "email_verified")
+    private Boolean emailVerified = false;
+    
+    @Column(length = 20)
+    private String phone;
+    
+    @Column(name = "phone_verified")
+    private Boolean phoneVerified = false;
+    
+    @Column(name = "mfa_enabled")
+    private Boolean mfaEnabled = false;
+    
+    @Column(name = "mfa_secret", length = 32)
+    private String mfaSecret;
+    
+    // Profile fields
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_image_id")
+    private File profileImage;
+    
+    @Column(length = 50)
+    private String timezone = "UTC";
+    
+    @Column(length = 10)
+    private String language = "en";
+    
+    // Security fields
+    @Column(name = "failed_login_attempts")
+    private Integer failedLoginAttempts = 0;
+    
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+    
+    @Column(name = "must_change_password")
+    private Boolean mustChangePassword = false;
+    
+    @Column(name = "last_password_change")
+    private LocalDateTime lastPasswordChange = LocalDateTime.now();
+    
+    // Flexible metadata storage
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> metadata;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> preferences;
+    
+    // Activity tracking
+    @Column(name = "last_login")
+    private LocalDateTime lastLogin;
+    
+    @Column(name = "last_activity")
+    private LocalDateTime lastActivity;
+}

--- a/src/main/java/com/example/mrquiz/entity/auth/UserProfile.java
+++ b/src/main/java/com/example/mrquiz/entity/auth/UserProfile.java
@@ -1,0 +1,71 @@
+package com.example.mrquiz.entity.auth;
+
+import com.example.mrquiz.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "user_profiles")
+public class UserProfile extends BaseEntity {
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @MapsId
+    private User user;
+    
+    @Column(columnDefinition = "TEXT")
+    private String bio;
+    
+    @Column(length = 255)
+    private String website;
+    
+    @Column(name = "linkedin_url", length = 255)
+    private String linkedinUrl;
+    
+    @Column(name = "twitter_handle", length = 50)
+    private String twitterHandle;
+    
+    // Academic and professional information stored as JSON
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "academic_info", columnDefinition = "jsonb")
+    private Map<String, Object> academicInfo;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "professional_info", columnDefinition = "jsonb")
+    private Map<String, Object> professionalInfo;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> certifications;
+    
+    // Preferences
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "notification_preferences", columnDefinition = "jsonb")
+    private Map<String, Object> notificationPreferences;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "privacy_settings", columnDefinition = "jsonb")
+    private Map<String, Object> privacySettings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "accessibility_settings", columnDefinition = "jsonb")
+    private Map<String, Object> accessibilitySettings;
+    
+    // Statistics
+    @Column(name = "total_quizzes_taken")
+    private Integer totalQuizzesTaken = 0;
+    
+    @Column(name = "total_quizzes_created")
+    private Integer totalQuizzesCreated = 0;
+    
+    @Column(name = "average_score", precision = 5, scale = 2)
+    private BigDecimal averageScore;
+}

--- a/src/main/java/com/example/mrquiz/entity/auth/UserSession.java
+++ b/src/main/java/com/example/mrquiz/entity/auth/UserSession.java
@@ -1,0 +1,44 @@
+package com.example.mrquiz.entity.auth;
+
+import com.example.mrquiz.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "user_sessions")
+public class UserSession extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @Column(name = "session_token", nullable = false, unique = true)
+    private String sessionToken;
+    
+    @Column(name = "ip_address")
+    private String ipAddress;
+    
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> location;
+    
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+    
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+    
+    @Column(name = "last_activity")
+    private LocalDateTime lastActivity = LocalDateTime.now();
+}

--- a/src/main/java/com/example/mrquiz/entity/core/Course.java
+++ b/src/main/java/com/example/mrquiz/entity/core/Course.java
@@ -1,0 +1,98 @@
+package com.example.mrquiz.entity.core;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.entity.file.File;
+import com.example.mrquiz.enums.CourseStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "courses", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"institution_id", "code", "academic_year", "semester"}),
+       indexes = {
+           @Index(name = "idx_courses_instructor", columnList = "instructor_id, status")
+       })
+public class Course extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "institution_id", nullable = false)
+    private Institution institution;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+    
+    // Course identification
+    @Column(nullable = false, length = 20)
+    private String code;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @Column(columnDefinition = "TEXT")
+    private String syllabus;
+    
+    // Academic details
+    private Integer credits;
+    
+    @Column(length = 20)
+    private String level; // undergraduate, graduate, professional
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> prerequisites;
+    
+    // Schedule
+    @Column(length = 50)
+    private String semester;
+    
+    @Column(name = "academic_year", length = 20)
+    private String academicYear;
+    
+    @Column(name = "start_date")
+    private LocalDate startDate;
+    
+    @Column(name = "end_date")
+    private LocalDate endDate;
+    
+    // Instructor
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instructor_id")
+    private User instructor;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "teaching_assistants", columnDefinition = "jsonb")
+    private List<UUID> teachingAssistants; // Array of user IDs
+    
+    // Configuration
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "grading_scale", columnDefinition = "jsonb")
+    private Map<String, Object> gradingScale;
+    
+    // Media
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cover_image_id")
+    private File coverImage;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CourseStatus status = CourseStatus.DRAFT;
+}

--- a/src/main/java/com/example/mrquiz/entity/core/CourseEnrollment.java
+++ b/src/main/java/com/example/mrquiz/entity/core/CourseEnrollment.java
@@ -1,0 +1,57 @@
+package com.example.mrquiz.entity.core;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.EnrollmentStatus;
+import com.example.mrquiz.enums.EnrollmentType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "course_enrollments", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"course_id", "user_id"}),
+       indexes = {
+           @Index(name = "idx_course_enrollments_student", columnList = "user_id, status"),
+           @Index(name = "idx_course_enrollments_course", columnList = "course_id, status")
+       })
+public class CourseEnrollment extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "enrollment_type", nullable = false)
+    private EnrollmentType enrollmentType = EnrollmentType.REGULAR;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EnrollmentStatus status = EnrollmentStatus.ACTIVE;
+    
+    // Grading
+    @Column(name = "final_grade", precision = 5, scale = 2)
+    private BigDecimal finalGrade;
+    
+    @Column(name = "grade_letter", length = 5)
+    private String gradeLetter;
+    
+    @Column(name = "gpa_points", precision = 3, scale = 2)
+    private BigDecimal gpaPoints;
+    
+    // Timestamps
+    @Column(name = "enrolled_at")
+    private LocalDateTime enrolledAt = LocalDateTime.now();
+    
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/com/example/mrquiz/entity/core/Department.java
+++ b/src/main/java/com/example/mrquiz/entity/core/Department.java
@@ -1,0 +1,45 @@
+package com.example.mrquiz.entity.core;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "departments", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"institution_id", "code"}),
+       indexes = @Index(name = "idx_departments_institution", columnList = "institution_id"))
+public class Department extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "institution_id", nullable = false)
+    private Institution institution;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_department_id")
+    private Department parentDepartment;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(length = 20)
+    private String code;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "head_user_id")
+    private User headUser;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+}

--- a/src/main/java/com/example/mrquiz/entity/core/Institution.java
+++ b/src/main/java/com/example/mrquiz/entity/core/Institution.java
@@ -1,0 +1,83 @@
+package com.example.mrquiz.entity.core;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.file.File;
+import com.example.mrquiz.enums.InstitutionStatus;
+import com.example.mrquiz.enums.InstitutionType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "institutions", indexes = {
+    @Index(name = "idx_institutions_domain", columnList = "domain"),
+    @Index(name = "idx_institutions_status", columnList = "status")
+})
+public class Institution extends BaseEntity {
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(unique = true, length = 100)
+    private String slug; // URL-friendly identifier
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InstitutionType type;
+    
+    // Contact information
+    private String email;
+    
+    @Column(length = 20)
+    private String phone;
+    
+    private String website;
+    
+    // Address stored as JSON
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> address;
+    
+    // Configuration
+    @Column(length = 100)
+    private String domain; // Email domain for auto-enrollment
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "logo_id")
+    private File logo;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> branding;
+    
+    // Features and limits
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> features;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> limits;
+    
+    // Status and billing
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InstitutionStatus status = InstitutionStatus.ACTIVE;
+    
+    @Column(name = "subscription_tier", length = 50)
+    private String subscriptionTier = "basic";
+    
+    @Column(name = "trial_ends_at")
+    private LocalDateTime trialEndsAt;
+}

--- a/src/main/java/com/example/mrquiz/entity/core/UserInstitution.java
+++ b/src/main/java/com/example/mrquiz/entity/core/UserInstitution.java
@@ -1,0 +1,62 @@
+package com.example.mrquiz.entity.core;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.InstitutionRole;
+import com.example.mrquiz.enums.MembershipStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "user_institutions", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "institution_id"}),
+       indexes = @Index(name = "idx_user_institutions_active", columnList = "user_id, institution_id, status"))
+public class UserInstitution extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "institution_id", nullable = false)
+    private Institution institution;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InstitutionRole role;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MembershipStatus status = MembershipStatus.ACTIVE;
+    
+    // Additional identification
+    @Column(name = "student_id", length = 50)
+    private String studentId;
+    
+    @Column(name = "employee_id", length = 50)
+    private String employeeId;
+    
+    // Permissions
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> permissions;
+    
+    // Timestamps
+    @Column(name = "joined_at")
+    private LocalDateTime joinedAt = LocalDateTime.now();
+    
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
+}

--- a/src/main/java/com/example/mrquiz/entity/file/File.java
+++ b/src/main/java/com/example/mrquiz/entity/file/File.java
@@ -1,0 +1,109 @@
+package com.example.mrquiz.entity.file;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.FileStatus;
+import com.example.mrquiz.enums.FileType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "files", indexes = {
+    @Index(name = "idx_files_uploader", columnList = "uploadedBy, createdAt"),
+    @Index(name = "idx_files_status", columnList = "status"),
+    @Index(name = "idx_files_hash", columnList = "fileHash"),
+    @Index(name = "idx_files_type_public", columnList = "fileType, isPublic")
+})
+public class File extends BaseEntity {
+    
+    @Column(nullable = false)
+    private String filename;
+    
+    @Column(name = "original_filename", nullable = false)
+    private String originalFilename;
+    
+    @Column(name = "file_path", nullable = false, columnDefinition = "TEXT")
+    private String filePath;
+    
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+    
+    @Column(name = "mime_type", nullable = false, length = 100)
+    private String mimeType;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "file_type", nullable = false)
+    private FileType fileType;
+    
+    @Column(name = "file_hash", nullable = false, length = 64)
+    private String fileHash;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FileStatus status = FileStatus.UPLOADING;
+    
+    // Storage metadata
+    @Column(name = "storage_provider", length = 50)
+    private String storageProvider = "local";
+    
+    @Column(name = "storage_region", length = 50)
+    private String storageRegion;
+    
+    @Column(name = "storage_bucket", length = 100)
+    private String storageBucket;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "storage_metadata", columnDefinition = "jsonb")
+    private Map<String, Object> storageMetadata;
+    
+    // File metadata
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> dimensions;
+    
+    @Column
+    private Integer duration; // For audio/video in seconds
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "encoding_info", columnDefinition = "jsonb")
+    private Map<String, Object> encodingInfo;
+    
+    // Access control
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "uploaded_by", nullable = false)
+    private User uploadedBy;
+    
+    @Column(name = "is_public")
+    private Boolean isPublic = false;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "access_permissions", columnDefinition = "jsonb")
+    private Map<String, Object> accessPermissions;
+    
+    // Processing info
+    @Column(name = "processing_status")
+    private String processingStatus = "pending";
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "processing_metadata", columnDefinition = "jsonb")
+    private Map<String, Object> processingMetadata;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "processed_variants", columnDefinition = "jsonb")
+    private Map<String, Object> processedVariants;
+    
+    // Lifecycle
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+    
+    @Column(name = "archived_at")
+    private LocalDateTime archivedAt;
+}

--- a/src/main/java/com/example/mrquiz/entity/file/FileVariant.java
+++ b/src/main/java/com/example/mrquiz/entity/file/FileVariant.java
@@ -1,0 +1,43 @@
+package com.example.mrquiz.entity.file;
+
+import com.example.mrquiz.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "file_variants", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"parent_file_id", "variant_name"}),
+       indexes = @Index(name = "idx_file_variants_parent", columnList = "parent_file_id"))
+public class FileVariant extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "parent_file_id", nullable = false)
+    private File parentFile;
+    
+    @Column(name = "variant_name", nullable = false, length = 100)
+    private String variantName; // 'thumbnail', 'small', 'medium', 'webp', etc.
+    
+    @Column(name = "file_path", nullable = false, columnDefinition = "TEXT")
+    private String filePath;
+    
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+    
+    @Column(name = "mime_type", nullable = false, length = 100)
+    private String mimeType;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> dimensions;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "processing_metadata", columnDefinition = "jsonb")
+    private Map<String, Object> processingMetadata;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/Question.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/Question.java
@@ -1,0 +1,146 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.entity.core.Course;
+import com.example.mrquiz.entity.core.Institution;
+import com.example.mrquiz.enums.DifficultyLevel;
+import com.example.mrquiz.enums.QuestionStatus;
+import com.example.mrquiz.enums.QuestionType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "questions", indexes = {
+    @Index(name = "idx_questions_creator_status", columnList = "creator_id, status"),
+    @Index(name = "idx_questions_type_difficulty", columnList = "question_type, difficulty_level"),
+    @Index(name = "idx_questions_tags", columnList = "tags")
+})
+public class Question extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id")
+    private Institution institution;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+    
+    // Question content
+    private String title;
+    
+    @Column(name = "question_text", nullable = false, columnDefinition = "TEXT")
+    private String questionText;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type", nullable = false)
+    private QuestionType questionType;
+    
+    // Grading
+    @Column(precision = 5, scale = 2)
+    private BigDecimal points = BigDecimal.ONE;
+    
+    @Column(name = "negative_points", precision = 5, scale = 2)
+    private BigDecimal negativePoints = BigDecimal.ZERO;
+    
+    // Classification
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty_level")
+    private DifficultyLevel difficultyLevel = DifficultyLevel.MEDIUM;
+    
+    @Column(name = "bloom_taxonomy", length = 50)
+    private String bloomTaxonomy;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "learning_objectives", columnDefinition = "jsonb")
+    private List<String> learningObjectives;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "subject_areas", columnDefinition = "jsonb")
+    private List<String> subjectAreas;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> tags;
+    
+    // Content and explanation
+    @Column(columnDefinition = "TEXT")
+    private String explanation;
+    
+    @Column(columnDefinition = "TEXT")
+    private String hint;
+    
+    @Column(name = "solution_method", columnDefinition = "TEXT")
+    private String solutionMethod;
+    
+    // Media attachments
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "question_files", columnDefinition = "jsonb")
+    private List<UUID> questionFiles; // Array of file IDs
+    
+    // Question-specific data (flexible JSON structure)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "question_data", nullable = false, columnDefinition = "jsonb")
+    private Map<String, Object> questionData;
+    
+    // Answer validation for auto-grading
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "correct_answers", columnDefinition = "jsonb")
+    private Map<String, Object> correctAnswers;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "answer_validation", columnDefinition = "jsonb")
+    private Map<String, Object> answerValidation;
+    
+    // Usage and analytics
+    @Column(name = "usage_count")
+    private Integer usageCount = 0;
+    
+    @Column(name = "difficulty_index", precision = 5, scale = 4)
+    private BigDecimal difficultyIndex;
+    
+    @Column(name = "discrimination_index", precision = 5, scale = 4)
+    private BigDecimal discriminationIndex;
+    
+    // Accessibility
+    @Column(name = "alt_text", columnDefinition = "TEXT")
+    private String altText;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "accessibility_metadata", columnDefinition = "jsonb")
+    private Map<String, Object> accessibilityMetadata;
+    
+    // Versioning
+    @Column
+    private Integer version = 1;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_question_id")
+    private Question parentQuestion;
+    
+    // Sharing and permissions
+    @Column(name = "is_public")
+    private Boolean isPublic = false;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "sharing_permissions", columnDefinition = "jsonb")
+    private Map<String, Object> sharingPermissions;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuestionStatus status = QuestionStatus.ACTIVE;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/QuestionResponse.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/QuestionResponse.java
@@ -1,0 +1,82 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "question_responses", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"attempt_id", "question_id"}),
+       indexes = {
+           @Index(name = "idx_question_responses_attempt", columnList = "attempt_id"),
+           @Index(name = "idx_question_responses_question", columnList = "question_id")
+       })
+public class QuestionResponse extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "attempt_id", nullable = false)
+    private QuizAttempt attempt;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "quiz_question_id", nullable = false)
+    private QuizQuestion quizQuestion;
+    
+    // Response data (flexible JSON structure)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "answer_data", nullable = false, columnDefinition = "jsonb")
+    private Map<String, Object> answerData;
+    
+    // Grading information
+    @Column(name = "points_earned", precision = 5, scale = 2)
+    private BigDecimal pointsEarned;
+    
+    @Column(name = "max_points", precision = 5, scale = 2)
+    private BigDecimal maxPoints;
+    
+    @Column(name = "is_correct")
+    private Boolean isCorrect;
+    
+    @Column(name = "partial_credit", precision = 5, scale = 2)
+    private BigDecimal partialCredit;
+    
+    // Response metadata
+    @Column(name = "time_spent")
+    private Integer timeSpent = 0; // Time spent on this question in seconds
+    
+    @Column(name = "attempt_count")
+    private Integer attemptCount = 1; // Number of times answer was changed
+    
+    @Column(name = "confidence_level")
+    private Integer confidenceLevel; // Student's confidence (1-5)
+    
+    @Column(name = "flagged_for_review")
+    private Boolean flaggedForReview = false;
+    
+    // Timestamps
+    @Column(name = "first_answered_at")
+    private LocalDateTime firstAnsweredAt;
+    
+    @Column(name = "last_modified_at")
+    private LocalDateTime lastModifiedAt;
+    
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt = LocalDateTime.now();
+    
+    // Additional metadata
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "response_metadata", columnDefinition = "jsonb")
+    private Map<String, Object> responseMetadata; // Keystroke data, mouse movements, etc.
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/Quiz.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/Quiz.java
@@ -1,0 +1,142 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.entity.core.Course;
+import com.example.mrquiz.entity.core.Institution;
+import com.example.mrquiz.entity.file.File;
+import com.example.mrquiz.enums.QuizStatus;
+import com.example.mrquiz.enums.QuizType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "quizzes", indexes = {
+    @Index(name = "idx_quizzes_creator_status", columnList = "creator_id, status"),
+    @Index(name = "idx_quizzes_course", columnList = "course_id, status"),
+    @Index(name = "idx_quizzes_availability", columnList = "availability_start, availability_end")
+})
+public class Quiz extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id")
+    private Institution institution;
+    
+    // Basic information
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @Column(columnDefinition = "TEXT")
+    private String instructions;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "quiz_type", nullable = false)
+    private QuizType quizType = QuizType.QUIZ;
+    
+    // Scoring and grading
+    @Column(name = "total_points", precision = 10, scale = 2)
+    private BigDecimal totalPoints = BigDecimal.ZERO;
+    
+    @Column(name = "passing_score", precision = 5, scale = 2)
+    private BigDecimal passingScore;
+    
+    @Column(name = "grading_method", length = 50)
+    private String gradingMethod = "automatic";
+    
+    // Timing
+    @Column(name = "time_limit")
+    private Integer timeLimit; // Total time limit in minutes
+    
+    @Column(name = "time_per_question")
+    private Integer timePerQuestion; // Time per question in seconds
+    
+    // Attempt settings
+    @Column(name = "attempts_allowed")
+    private Integer attemptsAllowed = 1;
+    
+    @Column(name = "attempt_scoring", length = 50)
+    private String attemptScoring = "last";
+    
+    // Question settings
+    @Column(name = "shuffle_questions")
+    private Boolean shuffleQuestions = false;
+    
+    @Column(name = "shuffle_answers")
+    private Boolean shuffleAnswers = false;
+    
+    @Column(name = "questions_per_page")
+    private Integer questionsPerPage = 1;
+    
+    // Feedback and results
+    @Column(name = "show_results_immediately")
+    private Boolean showResultsImmediately = true;
+    
+    @Column(name = "show_correct_answers")
+    private Boolean showCorrectAnswers = true;
+    
+    @Column(name = "show_explanations")
+    private Boolean showExplanations = true;
+    
+    @Column(name = "allow_review")
+    private Boolean allowReview = true;
+    
+    // Access control
+    @Column(name = "availability_start")
+    private LocalDateTime availabilityStart;
+    
+    @Column(name = "availability_end")
+    private LocalDateTime availabilityEnd;
+    
+    private String password; // Optional password protection
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "ip_restrictions", columnDefinition = "jsonb")
+    private List<String> ipRestrictions;
+    
+    // Advanced settings
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "security_settings", columnDefinition = "jsonb")
+    private Map<String, Object> securitySettings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "proctoring_settings", columnDefinition = "jsonb")
+    private Map<String, Object> proctoringSettings;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "accessibility_settings", columnDefinition = "jsonb")
+    private Map<String, Object> accessibilitySettings;
+    
+    // Media
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "banner_image_id")
+    private File bannerImage;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuizStatus status = QuizStatus.DRAFT;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/QuizAttempt.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/QuizAttempt.java
@@ -1,0 +1,111 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.AttemptStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "quiz_attempts", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"quiz_id", "user_id", "attempt_number"}),
+       indexes = {
+           @Index(name = "idx_quiz_attempts_user_quiz", columnList = "user_id, quiz_id"),
+           @Index(name = "idx_quiz_attempts_status", columnList = "status, created_at"),
+           @Index(name = "idx_quiz_attempts_session", columnList = "session_id")
+       })
+public class QuizAttempt extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private QuizSession session;
+    
+    // Attempt information
+    @Column(name = "attempt_number", nullable = false)
+    private Integer attemptNumber = 1;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttemptStatus status = AttemptStatus.IN_PROGRESS;
+    
+    // Scoring
+    @Column(precision = 10, scale = 2)
+    private BigDecimal score;
+    
+    @Column(name = "total_points", precision = 10, scale = 2)
+    private BigDecimal totalPoints;
+    
+    @Column(precision = 5, scale = 2)
+    private BigDecimal percentage;
+    
+    @Column(length = 5)
+    private String grade;
+    
+    private Boolean passed;
+    
+    // Timing
+    @Column(name = "time_limit")
+    private Integer timeLimit; // Actual time limit used (in minutes)
+    
+    @Column(name = "time_spent")
+    private Integer timeSpent = 0; // Total time spent in seconds
+    
+    @Column(name = "started_at")
+    private LocalDateTime startedAt = LocalDateTime.now();
+    
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+    
+    @Column(name = "graded_at")
+    private LocalDateTime gradedAt;
+    
+    // Technical information
+    @Column(name = "ip_address")
+    private String ipAddress;
+    
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "browser_info", columnDefinition = "jsonb")
+    private Map<String, Object> browserInfo;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "device_info", columnDefinition = "jsonb")
+    private Map<String, Object> deviceInfo;
+    
+    // Security and proctoring
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "security_flags", columnDefinition = "jsonb")
+    private Map<String, Object> securityFlags;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "proctoring_data", columnDefinition = "jsonb")
+    private Map<String, Object> proctoringData;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "suspicious_activities", columnDefinition = "jsonb")
+    private Map<String, Object> suspiciousActivities;
+    
+    // Additional metadata
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> metadata;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/QuizQuestion.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/QuizQuestion.java
@@ -1,0 +1,53 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "quiz_questions", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"quiz_id", "order_index"}),
+       indexes = @Index(name = "idx_quiz_questions_order", columnList = "quiz_id, order_index"))
+public class QuizQuestion extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+    
+    // Position and grouping
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+    
+    @Column(length = 100)
+    private String section; // Optional section grouping
+    
+    @Column(name = "page_number")
+    private Integer pageNumber = 1;
+    
+    // Override settings
+    @Column(precision = 5, scale = 2)
+    private BigDecimal points; // Override default question points
+    
+    @Column(name = "time_limit")
+    private Integer timeLimit; // Override default time limit for this question
+    
+    @Column(nullable = false)
+    private Boolean required = true;
+    
+    // Question-specific settings in this quiz
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/QuizSession.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/QuizSession.java
@@ -1,0 +1,77 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.SessionStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "quiz_sessions")
+public class QuizSession extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_id", nullable = false)
+    private User host;
+    
+    // Session identification
+    @Column(name = "session_code", unique = true, nullable = false, length = 8)
+    private String sessionCode;
+    
+    private String name;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    // Access control
+    private String password;
+    
+    @Column(name = "max_participants")
+    private Integer maxParticipants;
+    
+    @Column(name = "allow_late_join")
+    private Boolean allowLateJoin = true;
+    
+    @Column(name = "require_registration")
+    private Boolean requireRegistration = false;
+    
+    // Timing
+    @Column(name = "scheduled_start")
+    private LocalDateTime scheduledStart;
+    
+    @Column(name = "scheduled_end")
+    private LocalDateTime scheduledEnd;
+    
+    @Column(name = "actual_start")
+    private LocalDateTime actualStart;
+    
+    @Column(name = "actual_end")
+    private LocalDateTime actualEnd;
+    
+    // Settings
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> settings;
+    
+    @Column(name = "real_time_results")
+    private Boolean realTimeResults = false;
+    
+    @Column(name = "show_leaderboard")
+    private Boolean showLeaderboard = false;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SessionStatus status = SessionStatus.SCHEDULED;
+}

--- a/src/main/java/com/example/mrquiz/entity/quiz/ResponseFile.java
+++ b/src/main/java/com/example/mrquiz/entity/quiz/ResponseFile.java
@@ -1,0 +1,30 @@
+package com.example.mrquiz.entity.quiz;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.file.File;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "response_files", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"response_id", "file_id"}),
+       indexes = @Index(name = "idx_response_files_response", columnList = "response_id"))
+public class ResponseFile extends BaseEntity {
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "response_id", nullable = false)
+    private QuestionResponse response;
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "file_id", nullable = false)
+    private File file;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @Column(name = "order_index")
+    private Integer orderIndex = 0;
+}

--- a/src/main/java/com/example/mrquiz/entity/security/AuditLog.java
+++ b/src/main/java/com/example/mrquiz/entity/security/AuditLog.java
@@ -1,0 +1,80 @@
+package com.example.mrquiz.entity.security;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.enums.SeverityLevel;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "audit_logs", indexes = {
+    @Index(name = "idx_audit_logs_user_created", columnList = "user_id, created_at"),
+    @Index(name = "idx_audit_logs_entity", columnList = "entity_type, entity_id, created_at")
+})
+public class AuditLog extends BaseEntity {
+    
+    // Actor information
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    
+    @Column(name = "session_id")
+    private String sessionId;
+    
+    // Action details
+    @Column(name = "entity_type", nullable = false, length = 50)
+    private String entityType;
+    
+    @Column(name = "entity_id")
+    private UUID entityId;
+    
+    @Column(nullable = false, length = 50)
+    private String action;
+    
+    // Change tracking
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "old_values", columnDefinition = "jsonb")
+    private Map<String, Object> oldValues;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "new_values", columnDefinition = "jsonb")
+    private Map<String, Object> newValues;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "changed_fields", columnDefinition = "jsonb")
+    private List<String> changedFields;
+    
+    // Request context
+    @Column(name = "ip_address")
+    private String ipAddress;
+    
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+    
+    @Column(name = "request_method", length = 10)
+    private String requestMethod;
+    
+    @Column(name = "request_path", columnDefinition = "TEXT")
+    private String requestPath;
+    
+    @Column(name = "request_id", length = 100)
+    private String requestId;
+    
+    // Additional context
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> metadata;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeverityLevel severity = SeverityLevel.INFO;
+}

--- a/src/main/java/com/example/mrquiz/entity/security/SecurityIncident.java
+++ b/src/main/java/com/example/mrquiz/entity/security/SecurityIncident.java
@@ -1,0 +1,102 @@
+package com.example.mrquiz.entity.security;
+
+import com.example.mrquiz.entity.BaseEntity;
+import com.example.mrquiz.entity.auth.User;
+import com.example.mrquiz.entity.quiz.QuizAttempt;
+import com.example.mrquiz.entity.quiz.QuizSession;
+import com.example.mrquiz.enums.IncidentType;
+import com.example.mrquiz.enums.SeverityLevel;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "security_incidents", indexes = {
+    @Index(name = "idx_security_incidents_user", columnList = "user_id, created_at"),
+    @Index(name = "idx_security_incidents_status", columnList = "status, severity")
+})
+public class SecurityIncident extends BaseEntity {
+    
+    // Context
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attempt_id")
+    private QuizAttempt attempt;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private QuizSession session;
+    
+    // Incident details
+    @Enumerated(EnumType.STRING)
+    @Column(name = "incident_type", nullable = false)
+    private IncidentType incidentType;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeverityLevel severity = SeverityLevel.LOW;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    // Detection
+    @Column(name = "detected_by", length = 50)
+    private String detectedBy = "system";
+    
+    @Column(name = "detection_method", length = 100)
+    private String detectionMethod;
+    
+    @Column(name = "confidence_score", precision = 5, scale = 4)
+    private BigDecimal confidenceScore;
+    
+    // Evidence
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> evidence;
+    
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "related_logs", columnDefinition = "jsonb")
+    private List<UUID> relatedLogs;
+    
+    // Resolution
+    @Column(length = 50)
+    private String status = "open";
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_to")
+    private User assignedTo;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resolved_by")
+    private User resolvedBy;
+    
+    @Column(name = "resolution_notes", columnDefinition = "TEXT")
+    private String resolutionNotes;
+    
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+    
+    // Actions taken
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "actions_taken", columnDefinition = "jsonb")
+    private Map<String, Object> actionsTaken;
+    
+    @Column(name = "follow_up_required")
+    private Boolean followUpRequired = false;
+}

--- a/src/main/java/com/example/mrquiz/enums/AttemptStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/AttemptStatus.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum AttemptStatus {
+    IN_PROGRESS,
+    SUBMITTED,
+    GRADED,
+    ABANDONED,
+    FLAGGED,
+    EXPIRED
+}

--- a/src/main/java/com/example/mrquiz/enums/CourseStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/CourseStatus.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum CourseStatus {
+    ACTIVE,
+    INACTIVE,
+    ARCHIVED,
+    DRAFT,
+    SCHEDULED
+}

--- a/src/main/java/com/example/mrquiz/enums/DifficultyLevel.java
+++ b/src/main/java/com/example/mrquiz/enums/DifficultyLevel.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum DifficultyLevel {
+    VERY_EASY,
+    EASY,
+    MEDIUM,
+    HARD,
+    VERY_HARD
+}

--- a/src/main/java/com/example/mrquiz/enums/EnrollmentStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/EnrollmentStatus.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum EnrollmentStatus {
+    ACTIVE,
+    DROPPED,
+    COMPLETED,
+    WITHDRAWN,
+    FAILED
+}

--- a/src/main/java/com/example/mrquiz/enums/EnrollmentType.java
+++ b/src/main/java/com/example/mrquiz/enums/EnrollmentType.java
@@ -1,0 +1,8 @@
+package com.example.mrquiz.enums;
+
+public enum EnrollmentType {
+    REGULAR,
+    AUDIT,
+    CREDIT,
+    GUEST
+}

--- a/src/main/java/com/example/mrquiz/enums/FileStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/FileStatus.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum FileStatus {
+    UPLOADING,
+    PROCESSING,
+    READY,
+    FAILED,
+    ARCHIVED
+}

--- a/src/main/java/com/example/mrquiz/enums/FileType.java
+++ b/src/main/java/com/example/mrquiz/enums/FileType.java
@@ -1,0 +1,12 @@
+package com.example.mrquiz.enums;
+
+public enum FileType {
+    IMAGE,
+    AUDIO,
+    VIDEO,
+    DOCUMENT,
+    ARCHIVE,
+    CODE,
+    DATA,
+    OTHER
+}

--- a/src/main/java/com/example/mrquiz/enums/IncidentType.java
+++ b/src/main/java/com/example/mrquiz/enums/IncidentType.java
@@ -1,0 +1,12 @@
+package com.example.mrquiz.enums;
+
+public enum IncidentType {
+    TAB_SWITCH,
+    COPY_PASTE,
+    SUSPICIOUS_BEHAVIOR,
+    MULTIPLE_LOGINS,
+    TIME_MANIPULATION,
+    CHEATING_DETECTED,
+    UNAUTHORIZED_HELP,
+    TECHNICAL_ISSUE
+}

--- a/src/main/java/com/example/mrquiz/enums/InstitutionRole.java
+++ b/src/main/java/com/example/mrquiz/enums/InstitutionRole.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum InstitutionRole {
+    STUDENT,
+    TEACHER,
+    ADMIN,
+    FACULTY,
+    STAFF,
+    GUEST
+}

--- a/src/main/java/com/example/mrquiz/enums/InstitutionStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/InstitutionStatus.java
@@ -1,0 +1,8 @@
+package com.example.mrquiz.enums;
+
+public enum InstitutionStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED,
+    TRIAL
+}

--- a/src/main/java/com/example/mrquiz/enums/InstitutionType.java
+++ b/src/main/java/com/example/mrquiz/enums/InstitutionType.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum InstitutionType {
+    SCHOOL,
+    UNIVERSITY,
+    COLLEGE,
+    TRAINING_CENTER,
+    CORPORATE,
+    INDIVIDUAL
+}

--- a/src/main/java/com/example/mrquiz/enums/MembershipStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/MembershipStatus.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum MembershipStatus {
+    ACTIVE,
+    INACTIVE,
+    GRADUATED,
+    TRANSFERRED,
+    EXPELLED
+}

--- a/src/main/java/com/example/mrquiz/enums/QuestionStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/QuestionStatus.java
@@ -1,0 +1,8 @@
+package com.example.mrquiz.enums;
+
+public enum QuestionStatus {
+    ACTIVE,
+    INACTIVE,
+    ARCHIVED,
+    UNDER_REVIEW
+}

--- a/src/main/java/com/example/mrquiz/enums/QuestionType.java
+++ b/src/main/java/com/example/mrquiz/enums/QuestionType.java
@@ -1,0 +1,21 @@
+package com.example.mrquiz.enums;
+
+public enum QuestionType {
+    MULTIPLE_CHOICE,
+    TRUE_FALSE,
+    SHORT_ANSWER,
+    ESSAY,
+    FILL_BLANK,
+    MATCHING,
+    ORDERING,
+    CODE,
+    MATH,
+    IMAGE_BASED,
+    AUDIO,
+    VIDEO,
+    DIAGRAM_LABELING,
+    CLINICAL_CASE,
+    LAB_SIMULATION,
+    GRAPH_ANALYSIS,
+    DATA_INTERPRETATION
+}

--- a/src/main/java/com/example/mrquiz/enums/QuizStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/QuizStatus.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum QuizStatus {
+    DRAFT,
+    PUBLISHED,
+    ARCHIVED,
+    SCHEDULED,
+    ACTIVE,
+    COMPLETED
+}

--- a/src/main/java/com/example/mrquiz/enums/QuizType.java
+++ b/src/main/java/com/example/mrquiz/enums/QuizType.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum QuizType {
+    QUIZ,
+    EXAM,
+    ASSIGNMENT,
+    SURVEY,
+    PRACTICE,
+    CERTIFICATION
+}

--- a/src/main/java/com/example/mrquiz/enums/SessionStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/SessionStatus.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum SessionStatus {
+    SCHEDULED,
+    ACTIVE,
+    PAUSED,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/com/example/mrquiz/enums/SeverityLevel.java
+++ b/src/main/java/com/example/mrquiz/enums/SeverityLevel.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum SeverityLevel {
+    INFO,
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}

--- a/src/main/java/com/example/mrquiz/enums/TokenType.java
+++ b/src/main/java/com/example/mrquiz/enums/TokenType.java
@@ -1,0 +1,9 @@
+package com.example.mrquiz.enums;
+
+public enum TokenType {
+    EMAIL_VERIFICATION,
+    PASSWORD_RESET,
+    REFRESH_TOKEN,
+    API_TOKEN,
+    MFA_TOKEN
+}

--- a/src/main/java/com/example/mrquiz/enums/UserRole.java
+++ b/src/main/java/com/example/mrquiz/enums/UserRole.java
@@ -1,0 +1,10 @@
+package com.example.mrquiz.enums;
+
+public enum UserRole {
+    STUDENT,
+    TEACHER,
+    ADMIN,
+    SUPER_ADMIN,
+    FACULTY,
+    DEPARTMENT_ADMIN
+}

--- a/src/main/java/com/example/mrquiz/enums/UserStatus.java
+++ b/src/main/java/com/example/mrquiz/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package com.example.mrquiz.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED,
+    PENDING_VERIFICATION
+}


### PR DESCRIPTION
Adds JPA entities and enums to implement the PostgreSQL database schema for the SmartQuiz platform.

---
<a href="https://cursor.com/background-agent?bcId=bc-57a2dda2-042c-4a3b-8270-87330dd5307b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57a2dda2-042c-4a3b-8270-87330dd5307b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>